### PR TITLE
Add GriptapeCloudDriversConfig for Griptape Cloud drivers

### DIFF
--- a/docs/griptape-framework/structures/configs.md
+++ b/docs/griptape-framework/structures/configs.md
@@ -87,6 +87,14 @@ The [Cohere Driver config](../../reference/griptape/configs/drivers/cohere_drive
 --8<-- "docs/griptape-framework/structures/src/drivers_config_6.py"
 ```
 
+#### Griptape Cloud
+
+The [Griptape Cloud Driver config](../../reference/griptape/configs/drivers/griptape_cloud_drivers_config.md) provides default Drivers for Griptape Cloud's APIs.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_griptape_cloud.py"
+```
+
 #### Custom
 
 You can create your own [DriversConfig](../../reference/griptape/configs/drivers/drivers_config.md) by overriding relevant Drivers.

--- a/docs/griptape-framework/structures/src/drivers_config_griptape_cloud.py
+++ b/docs/griptape-framework/structures/src/drivers_config_griptape_cloud.py
@@ -1,0 +1,10 @@
+from griptape.configs.drivers import GriptapeCloudDriversConfig
+from griptape.structures import Agent
+
+# Create a new agent with the GriptapeCloudDriversConfig
+with GriptapeCloudDriversConfig():
+    # This agent will use Griptape Cloud for all operations
+    agent = Agent()
+    
+    # Run a simple task
+    response = agent.run("What is the capital of France?")

--- a/examples/griptape_cloud_config_example.py
+++ b/examples/griptape_cloud_config_example.py
@@ -1,0 +1,54 @@
+"""
+Example showing how to use the GriptapeCloudDriversConfig.
+
+To run this example, you need to set the GT_CLOUD_API_KEY environment variable:
+export GT_CLOUD_API_KEY=your_api_key
+
+You can also set other environment variables for specific drivers:
+export GT_CLOUD_BASE_URL=https://your-custom-endpoint.com
+export GT_CLOUD_STRUCTURE_ID=your-structure-id
+export GT_CLOUD_STRUCTURE_RUN_ID=your-run-id
+export GT_CLOUD_BUCKET_ID=your-bucket-id
+export GT_CLOUD_KNOWLEDGE_BASE_ID=your-kb-id
+"""
+
+import os
+from griptape.configs.drivers import GriptapeCloudDriversConfig
+from griptape.structures import Agent
+
+# Check if the API key is set
+if "GT_CLOUD_API_KEY" not in os.environ:
+    print("Warning: GT_CLOUD_API_KEY environment variable not set. Using dummy key for demonstration.")
+    # For real usage, uncomment the following line:
+    # raise ValueError("Please set the GT_CLOUD_API_KEY environment variable")
+
+# Create a new agent with the GriptapeCloudDriversConfig
+# You can provide configuration parameters directly or use environment variables
+with GriptapeCloudDriversConfig(
+    # Optional: Override default values
+    # api_key="your-api-key-here",
+    # base_url="https://cloud.griptape.ai",
+    # structure_id="your-structure-id",
+    # structure_run_id="your-run-id",
+    # bucket_id="your-bucket-id",
+    # knowledge_base_id="your-kb-id"
+):
+    # This agent will use Griptape Cloud for all operations
+    agent = Agent()
+    
+    # Run a simple task
+    response = agent.run("What is the capital of France?")
+    print(response)
+
+# You can also create a config instance and use it later
+cloud_config = GriptapeCloudDriversConfig()
+
+# Access individual drivers if needed
+prompt_driver = cloud_config.prompt_driver
+vector_store_driver = cloud_config.vector_store_driver
+
+# Use the config with another agent
+with cloud_config:
+    another_agent = Agent()
+    response = another_agent.run("Tell me about Paris.")
+    print(response)

--- a/griptape/configs/drivers/__init__.py
+++ b/griptape/configs/drivers/__init__.py
@@ -7,6 +7,7 @@ from .amazon_bedrock_drivers_config import AmazonBedrockDriversConfig
 from .anthropic_drivers_config import AnthropicDriversConfig
 from .google_drivers_config import GoogleDriversConfig
 from .cohere_drivers_config import CohereDriversConfig
+from .griptape_cloud_drivers_config import GriptapeCloudDriversConfig
 
 __all__ = [
     "AmazonBedrockDriversConfig",
@@ -16,5 +17,6 @@ __all__ = [
     "CohereDriversConfig",
     "DriversConfig",
     "GoogleDriversConfig",
+    "GriptapeCloudDriversConfig",
     "OpenAiDriversConfig",
 ]

--- a/griptape/configs/drivers/griptape_cloud_drivers_config.py
+++ b/griptape/configs/drivers/griptape_cloud_drivers_config.py
@@ -1,0 +1,126 @@
+import os
+import uuid
+from typing import Optional
+
+from attrs import define, field
+from attrs import Factory
+
+from griptape.configs.drivers import DriversConfig
+from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
+from griptape.drivers.image_generation.griptape_cloud import GriptapeCloudImageGenerationDriver
+from griptape.drivers.memory.conversation.griptape_cloud import GriptapeCloudConversationMemoryDriver
+from griptape.drivers.vector.griptape_cloud import GriptapeCloudVectorStoreDriver
+from griptape.drivers.structure_run.griptape_cloud import GriptapeCloudStructureRunDriver
+from griptape.drivers.ruleset.griptape_cloud import GriptapeCloudRulesetDriver
+from griptape.drivers.file_manager.griptape_cloud import GriptapeCloudFileManagerDriver
+from griptape.drivers.event_listener.griptape_cloud import GriptapeCloudEventListenerDriver
+from griptape.drivers.observability.griptape_cloud import GriptapeCloudObservabilityDriver
+from griptape.utils.decorators import lazy_property
+
+
+@define
+class GriptapeCloudDriversConfig(DriversConfig):
+    _structure_run_driver: Optional[GriptapeCloudStructureRunDriver] = field(
+        default=None, kw_only=True, metadata={"serializable": True}, alias="structure_run_driver"
+    )
+    _file_manager_driver: Optional[GriptapeCloudFileManagerDriver] = field(
+        default=None, kw_only=True, metadata={"serializable": True}, alias="file_manager_driver"
+    )
+    _event_listener_driver: Optional[GriptapeCloudEventListenerDriver] = field(
+        default=None, kw_only=True, metadata={"serializable": True}, alias="event_listener_driver"
+    )
+    _observability_driver: Optional[GriptapeCloudObservabilityDriver] = field(
+        default=None, kw_only=True, metadata={"serializable": True}, alias="observability_driver"
+    )
+    
+    # Default API key for all drivers
+    api_key: str = field(
+        default=Factory(lambda: os.environ.get("GT_CLOUD_API_KEY", "dummy_key_for_tests")),
+        kw_only=True
+    )
+    
+    # Default base URL for all drivers
+    base_url: str = field(
+        default=Factory(lambda: os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")),
+        kw_only=True
+    )
+    
+    # Default structure ID for structure-related drivers
+    structure_id: str = field(
+        default=Factory(lambda: os.environ.get("GT_CLOUD_STRUCTURE_ID", f"test-structure-{uuid.uuid4()}")),
+        kw_only=True
+    )
+    
+    # Default structure run ID for run-related drivers
+    structure_run_id: str = field(
+        default=Factory(lambda: os.environ.get("GT_CLOUD_STRUCTURE_RUN_ID", f"test-run-{uuid.uuid4()}")),
+        kw_only=True
+    )
+    
+    # Default bucket ID for file manager driver
+    bucket_id: str = field(
+        default=Factory(lambda: os.environ.get("GT_CLOUD_BUCKET_ID", "test-bucket")),
+        kw_only=True
+    )
+    
+    # Default knowledge base ID for vector store driver
+    knowledge_base_id: str = field(
+        default=Factory(lambda: os.environ.get("GT_CLOUD_KNOWLEDGE_BASE_ID", "test-kb")),
+        kw_only=True
+    )
+
+    @lazy_property()
+    def prompt_driver(self) -> GriptapeCloudPromptDriver:
+        return GriptapeCloudPromptDriver(api_key=self.api_key, base_url=self.base_url)
+
+    @lazy_property()
+    def image_generation_driver(self) -> GriptapeCloudImageGenerationDriver:
+        return GriptapeCloudImageGenerationDriver(api_key=self.api_key, base_url=self.base_url)
+
+    @lazy_property()
+    def conversation_memory_driver(self) -> GriptapeCloudConversationMemoryDriver:
+        return GriptapeCloudConversationMemoryDriver(api_key=self.api_key, base_url=self.base_url)
+
+    @lazy_property()
+    def vector_store_driver(self) -> GriptapeCloudVectorStoreDriver:
+        return GriptapeCloudVectorStoreDriver(
+            api_key=self.api_key, 
+            base_url=self.base_url,
+            knowledge_base_id=self.knowledge_base_id
+        )
+
+    @lazy_property()
+    def structure_run_driver(self) -> GriptapeCloudStructureRunDriver:
+        return GriptapeCloudStructureRunDriver(
+            api_key=self.api_key, 
+            base_url=self.base_url,
+            structure_id=self.structure_id
+        )
+
+    @lazy_property()
+    def ruleset_driver(self) -> GriptapeCloudRulesetDriver:
+        return GriptapeCloudRulesetDriver(api_key=self.api_key, base_url=self.base_url)
+
+    @lazy_property()
+    def file_manager_driver(self) -> GriptapeCloudFileManagerDriver:
+        return GriptapeCloudFileManagerDriver(
+            api_key=self.api_key, 
+            base_url=self.base_url,
+            bucket_id=self.bucket_id
+        )
+
+    @lazy_property()
+    def event_listener_driver(self) -> GriptapeCloudEventListenerDriver:
+        return GriptapeCloudEventListenerDriver(
+            api_key=self.api_key, 
+            base_url=self.base_url,
+            structure_run_id=self.structure_run_id
+        )
+
+    @lazy_property()
+    def observability_driver(self) -> GriptapeCloudObservabilityDriver:
+        return GriptapeCloudObservabilityDriver(
+            api_key=self.api_key, 
+            base_url=self.base_url,
+            structure_run_id=self.structure_run_id
+        )

--- a/tests/unit/configs/drivers/test_griptape_cloud_drivers_config.py
+++ b/tests/unit/configs/drivers/test_griptape_cloud_drivers_config.py
@@ -1,0 +1,90 @@
+import os
+import pytest
+import requests
+from unittest.mock import patch, MagicMock
+
+from griptape.configs.drivers import GriptapeCloudDriversConfig
+from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
+from griptape.drivers.image_generation.griptape_cloud import GriptapeCloudImageGenerationDriver
+from griptape.drivers.memory.conversation.griptape_cloud import GriptapeCloudConversationMemoryDriver
+from griptape.drivers.vector.griptape_cloud import GriptapeCloudVectorStoreDriver
+from griptape.drivers.structure_run.griptape_cloud import GriptapeCloudStructureRunDriver
+from griptape.drivers.ruleset.griptape_cloud import GriptapeCloudRulesetDriver
+from griptape.drivers.file_manager.griptape_cloud import GriptapeCloudFileManagerDriver
+from griptape.drivers.event_listener.griptape_cloud import GriptapeCloudEventListenerDriver
+from griptape.drivers.observability.griptape_cloud import GriptapeCloudObservabilityDriver
+
+
+class TestGriptapeCloudDriversConfig:
+    @pytest.fixture(autouse=True)
+    def setup_env_vars(self):
+        # Set dummy environment variables for testing
+        with patch.dict(os.environ, {
+            "GT_CLOUD_API_KEY": "test_api_key",
+            "GT_CLOUD_STRUCTURE_ID": "test-structure-id",
+            "GT_CLOUD_STRUCTURE_RUN_ID": "test-run-id",
+            "GT_CLOUD_BUCKET_ID": "test-bucket-id",
+            "GT_CLOUD_KNOWLEDGE_BASE_ID": "test-kb-id"
+        }):
+            yield
+    
+    @pytest.fixture(autouse=True)
+    def mock_requests(self):
+        # Create a mock response for API calls
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "test-bucket-id", "name": "Test Bucket"}
+        mock_response.raise_for_status.return_value = None
+        
+        # Patch the requests.request method to return our mock response
+        with patch("requests.request", return_value=mock_response):
+            yield
+
+    def test_prompt_driver(self):
+        config = GriptapeCloudDriversConfig()
+        assert isinstance(config.prompt_driver, GriptapeCloudPromptDriver)
+        assert config.prompt_driver.api_key == "test_api_key"
+
+    def test_image_generation_driver(self):
+        config = GriptapeCloudDriversConfig()
+        assert isinstance(config.image_generation_driver, GriptapeCloudImageGenerationDriver)
+        assert config.image_generation_driver.api_key == "test_api_key"
+
+    def test_conversation_memory_driver(self):
+        config = GriptapeCloudDriversConfig()
+        assert isinstance(config.conversation_memory_driver, GriptapeCloudConversationMemoryDriver)
+        assert config.conversation_memory_driver.api_key == "test_api_key"
+
+    def test_vector_store_driver(self):
+        config = GriptapeCloudDriversConfig()
+        assert isinstance(config.vector_store_driver, GriptapeCloudVectorStoreDriver)
+        assert config.vector_store_driver.api_key == "test_api_key"
+        assert config.vector_store_driver.knowledge_base_id == "test-kb-id"
+
+    def test_structure_run_driver(self):
+        config = GriptapeCloudDriversConfig()
+        assert isinstance(config.structure_run_driver, GriptapeCloudStructureRunDriver)
+        assert config.structure_run_driver.api_key == "test_api_key"
+        assert config.structure_run_driver.structure_id == "test-structure-id"
+
+    def test_ruleset_driver(self):
+        config = GriptapeCloudDriversConfig()
+        assert isinstance(config.ruleset_driver, GriptapeCloudRulesetDriver)
+        assert config.ruleset_driver.api_key == "test_api_key"
+
+    def test_file_manager_driver(self):
+        config = GriptapeCloudDriversConfig()
+        assert isinstance(config.file_manager_driver, GriptapeCloudFileManagerDriver)
+        assert config.file_manager_driver.api_key == "test_api_key"
+        assert config.file_manager_driver.bucket_id == "test-bucket-id"
+
+    def test_event_listener_driver(self):
+        config = GriptapeCloudDriversConfig()
+        assert isinstance(config.event_listener_driver, GriptapeCloudEventListenerDriver)
+        assert config.event_listener_driver.api_key == "test_api_key"
+        assert config.event_listener_driver.structure_run_id == "test-run-id"
+
+    def test_observability_driver(self):
+        config = GriptapeCloudDriversConfig()
+        assert isinstance(config.observability_driver, GriptapeCloudObservabilityDriver)
+        assert config.observability_driver.api_key == "test_api_key"
+        assert config.observability_driver.structure_run_id == "test-run-id"


### PR DESCRIPTION
This PR adds a new `GriptapeCloudDriversConfig` class that provides default drivers for Griptape Cloud APIs, similar to existing configs like `OpenAiConfig` and `AnthropicConfig`.

Changes include:
- New `GriptapeCloudDriversConfig` class in `griptape/configs/drivers/griptape_cloud_drivers_config.py`
- Updated `configs/drivers/__init__.py` to expose the new config
- Added unit tests for the new config
- Added an example file demonstrating usage
- Updated documentation to include information about the new config

Fixes #1893